### PR TITLE
Change the criteria for follow relation and add object errors for signup and login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,22 +19,22 @@ repositories {
 }
 
 dependencies {
-    implementation 'mysql:mysql-connector-java:8.0.25'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:2.6.5'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-devtools'
+    implementation 'mysql:mysql-connector-java:8.0.28'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.6.6'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:2.6.6'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.6.6'
+    implementation 'org.springframework.boot:spring-boot-starter-validation:2.6.6'
+    implementation 'org.springframework.boot:spring-boot-devtools:2.6.6'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
     implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.8'
 
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'mysql:mysql-connector-java'
+    compileOnly 'org.projectlombok:lombok:1.18.22'
+    runtimeOnly 'mysql:mysql-connector-java:8.0.28'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.22'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.6.4'
-    testCompileOnly 'org.projectlombok:lombok'
-    testAnnotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.6.6'
+    testCompileOnly 'org.projectlombok:lombok:1.18.22'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'
 
     //JUnit4 추가
     testImplementation('org.junit.vintage:junit-vintage-engine:5.8.2') {

--- a/src/main/java/com/gokimpark/instaclone/domain/exception/AccountException.java
+++ b/src/main/java/com/gokimpark/instaclone/domain/exception/AccountException.java
@@ -1,0 +1,16 @@
+package com.gokimpark.instaclone.domain.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class AccountException extends RuntimeException {
+
+    public AccountException() {
+        super();
+    }
+
+    public AccountException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gokimpark/instaclone/domain/follow/FollowRepository.java
+++ b/src/main/java/com/gokimpark/instaclone/domain/follow/FollowRepository.java
@@ -1,6 +1,6 @@
 package com.gokimpark.instaclone.domain.follow;
 
-import com.gokimpark.instaclone.domain.follow.dto.FollowSimpleListDto;
+import com.gokimpark.instaclone.domain.follow.dto.UserSimpleInfoDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,11 +15,11 @@ public interface FollowRepository extends JpaRepository<Follow, Follow.PK> {
     Long countByToUser(Long userId);
     Long countByFromUser(Long userId);
 
-    @Query(value = "select new com.gokimpark.instaclone.domain.follow.dto.FollowSimpleListDto(u.username, u.name) from Follow f INNER JOIN User u ON f.toUser = u.id where f.fromUser = :userId")
-    List<FollowSimpleListDto> findAllByFromUser(@Param("userId") Long userId);
+    @Query(value = "select new com.gokimpark.instaclone.domain.follow.dto.UserSimpleInfoDto(u.username, u.name) from Follow f INNER JOIN User u ON f.toUser = u.id where f.fromUser = :userId")
+    List<UserSimpleInfoDto> findAllByFromUser(@Param("userId") Long userId);
 
-    @Query(value = "select new com.gokimpark.instaclone.domain.follow.dto.FollowSimpleListDto(u.username, u.name) from Follow f JOIN User u ON f.fromUser = u.id where f.toUser = :userId")
-    List<FollowSimpleListDto> findAllByToUser(@Param("userId") Long userId);
+    @Query(value = "select new com.gokimpark.instaclone.domain.follow.dto.UserSimpleInfoDto(u.username, u.name) from Follow f JOIN User u ON f.fromUser = u.id where f.toUser = :userId")
+    List<UserSimpleInfoDto> findAllByToUser(@Param("userId") Long userId);
 
     void deleteAllByFromUser(Long userId);
     void deleteAllByToUser(Long userId);

--- a/src/main/java/com/gokimpark/instaclone/domain/follow/dto/UserSimpleInfoDto.java
+++ b/src/main/java/com/gokimpark/instaclone/domain/follow/dto/UserSimpleInfoDto.java
@@ -3,14 +3,15 @@ package com.gokimpark.instaclone.domain.follow.dto;
 import lombok.Data;
 
 @Data
-public class FollowSimpleListDto {
+public class UserSimpleInfoDto {
 
-    private String profileImageUrl;
+    private String requestedUsername;
+    private Boolean isFollowing;
+
     private String username;
     private String name;
 
-    public FollowSimpleListDto(String username, String name) {
-        this.profileImageUrl = null;
+    public UserSimpleInfoDto(String username, String name) {
         this.username = username;
         this.name = name;
     }

--- a/src/main/java/com/gokimpark/instaclone/domain/user/ProfileService.java
+++ b/src/main/java/com/gokimpark/instaclone/domain/user/ProfileService.java
@@ -30,12 +30,13 @@ public class ProfileService {
 
         ProfileDto profileDto = new ProfileDto();
         ProfileUserInfoDto userInfoDto = mapper.map(toUser, ProfileUserInfoDto.class);
+        userInfoDto.setRequestedUsername(fromUsername);
         if(fromUser.getId().equals(toUser.getId())) {
             profileDto.setIsOneself(true);
         }
         else {
             profileDto.setIsOneself(false);
-            userInfoDto.setFollow(followService.isFollowById(toUser.getId(), fromUser.getId()));
+            userInfoDto.setFollowing(followService.isFollowingById(toUser.getId(), fromUser.getId()));
         }
         List<PostProfileDto> postProfileDtoList = postService.findAllProfilePostByUser(toUser.getUsername());
         userInfoDto.setPostCount((long) postProfileDtoList.size());
@@ -54,7 +55,8 @@ public class ProfileService {
         for(UserDto user : users) {
             if(user.getUsername().equals(username)) continue;
             ProfileUserInfoDto profileUserInfoDto = mapper.map(user, ProfileUserInfoDto.class);
-            profileUserInfoDto.setFollow(followService.isFollowByUsername(user.getUsername(), username));
+            profileUserInfoDto.setRequestedUsername(username);
+            profileUserInfoDto.setFollowing(followService.isFollowingByUsername(user.getUsername(), username));
             userInfoDtoList.add(profileUserInfoDto);
         }
         return userInfoDtoList;

--- a/src/main/java/com/gokimpark/instaclone/domain/user/dto/ProfileUserInfoDto.java
+++ b/src/main/java/com/gokimpark/instaclone/domain/user/dto/ProfileUserInfoDto.java
@@ -7,7 +7,8 @@ import javax.validation.constraints.NotBlank;
 @Data
 public class ProfileUserInfoDto {
 
-    private boolean follow;
+    private boolean isFollowing;
+    private String requestedUsername;
     @NotBlank
     private String name;
     @NotBlank

--- a/src/main/java/com/gokimpark/instaclone/utils/AccountErrorMessage.java
+++ b/src/main/java/com/gokimpark/instaclone/utils/AccountErrorMessage.java
@@ -1,0 +1,8 @@
+package com.gokimpark.instaclone.utils;
+
+public class AccountErrorMessage {
+
+    public static final String MISMATCH_LOGIN_ID = "입력한 사용자 이름을 사용하는 계정을 찾을 수 없습니다. 사용자 이름을 확인하고 다시 시도하세요.";
+    public static final String MISMATCH_PASSWORD = "잘못된 비밀번호입니다. 다시 확인하세요.";
+    public static final String DUPLICATE_USERNAME = "이미 사용중인 이름입니다.";
+}

--- a/src/main/java/com/gokimpark/instaclone/web/follow/FollowRestController.java
+++ b/src/main/java/com/gokimpark/instaclone/web/follow/FollowRestController.java
@@ -1,7 +1,7 @@
 package com.gokimpark.instaclone.web.follow;
 
 import com.gokimpark.instaclone.domain.follow.FollowService;
-import com.gokimpark.instaclone.domain.follow.dto.FollowSimpleListDto;
+import com.gokimpark.instaclone.domain.follow.dto.FollowSimpleUserInfoDto;
 import com.gokimpark.instaclone.domain.user.ProfileService;
 import com.gokimpark.instaclone.domain.user.dto.ProfileDto;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +12,9 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
+@RequestMapping("/REST")
 @RequiredArgsConstructor
-public class FollowController {
+public class FollowRestController {
 
     private final FollowService followService;
     private final ProfileService profileService;
@@ -40,13 +41,13 @@ public class FollowController {
 
     @GetMapping("/follower/{username}")
     public ResponseEntity<?> getFollower(@PathVariable String username){
-        List<FollowSimpleListDto> followerList = followService.getFollowerList(username);
+        List<FollowSimpleUserInfoDto> followerList = followService.getFollowerList(username);
         return new ResponseEntity<>(followerList, HttpStatus.OK);
     }
 
     @GetMapping("/following/{username}")
     public ResponseEntity<?> getFollowing(@PathVariable String username){
-        List<FollowSimpleListDto> followingList = followService.getFollowingList(username);
+        List<FollowSimpleUserInfoDto> followingList = followService.getFollowingList(username);
         return new ResponseEntity<>(followingList, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/gokimpark/instaclone/web/follow/FollowRestController.java
+++ b/src/main/java/com/gokimpark/instaclone/web/follow/FollowRestController.java
@@ -1,7 +1,7 @@
 package com.gokimpark.instaclone.web.follow;
 
 import com.gokimpark.instaclone.domain.follow.FollowService;
-import com.gokimpark.instaclone.domain.follow.dto.FollowSimpleUserInfoDto;
+import com.gokimpark.instaclone.domain.follow.dto.UserSimpleInfoDto;
 import com.gokimpark.instaclone.domain.user.ProfileService;
 import com.gokimpark.instaclone.domain.user.dto.ProfileDto;
 import lombok.RequiredArgsConstructor;
@@ -39,15 +39,15 @@ public class FollowRestController {
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
-    @GetMapping("/follower/{username}")
-    public ResponseEntity<?> getFollower(@PathVariable String username){
-        List<FollowSimpleUserInfoDto> followerList = followService.getFollowerList(username);
+    @GetMapping("/follower/{profileUsername}/{requestedUsername}")
+    public ResponseEntity<?> getFollower(@PathVariable String profileUsername, @PathVariable String requestedUsername){
+        List<UserSimpleInfoDto> followerList = followService.getFollowRelationList("follower", profileUsername, requestedUsername);
         return new ResponseEntity<>(followerList, HttpStatus.OK);
     }
 
-    @GetMapping("/following/{username}")
-    public ResponseEntity<?> getFollowing(@PathVariable String username){
-        List<FollowSimpleUserInfoDto> followingList = followService.getFollowingList(username);
+    @GetMapping("/following/{profileUsername}/{requestedUsername}")
+    public ResponseEntity<?> getFollowing(@PathVariable String profileUsername, @PathVariable String requestedUsername){
+        List<UserSimpleInfoDto> followingList = followService.getFollowRelationList("following", profileUsername, requestedUsername);
         return new ResponseEntity<>(followingList, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/gokimpark/instaclone/web/follow/FollowViewController.java
+++ b/src/main/java/com/gokimpark/instaclone/web/follow/FollowViewController.java
@@ -1,0 +1,49 @@
+package com.gokimpark.instaclone.web.follow;
+
+import com.gokimpark.instaclone.domain.follow.FollowService;
+import com.gokimpark.instaclone.domain.follow.dto.UserSimpleInfoDto;
+import com.gokimpark.instaclone.domain.user.ProfileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.util.List;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class FollowViewController {
+
+    private final FollowService followService;
+    private final ProfileService profileService;
+
+    @PostMapping("/follow/{toUsername}/{fromUsername}")
+    public String addFollow(@PathVariable String toUsername, @PathVariable String fromUsername){
+        Boolean result = followService.addFollow(toUsername, fromUsername);
+        return "redirect:/profile/{toUsername}/{fromUsername}";
+    }
+
+    @PostMapping("/unfollow/{toUsername}/{fromUsername}")
+    public String unFollow(@PathVariable String toUsername, @PathVariable String fromUsername){
+        Boolean result = followService.unFollow(toUsername, fromUsername);
+        return "redirect:/profile/{toUsername}/{fromUsername}";
+    }
+
+    @GetMapping("/follower/{fromUsername}/{requestedUsername}")
+    public String getFollower(@PathVariable String fromUsername, @PathVariable String requestedUsername, Model model){
+        List<UserSimpleInfoDto> followerList = followService.getFollowRelationList("follower", fromUsername, requestedUsername);
+        model.addAttribute("users", followerList);
+        return "/account/userList";
+    }
+
+    @GetMapping("/following/{fromUsername}/{requestedUsername}")
+    public String getFollowing(@PathVariable String fromUsername, @PathVariable String requestedUsername, Model model){
+        List<UserSimpleInfoDto> followingList = followService.getFollowRelationList("following", fromUsername, requestedUsername);
+        model.addAttribute("users", followingList);
+        return "/account/userList";
+    }
+}

--- a/src/main/java/com/gokimpark/instaclone/web/user/AccountViewController.java
+++ b/src/main/java/com/gokimpark/instaclone/web/user/AccountViewController.java
@@ -1,5 +1,6 @@
 package com.gokimpark.instaclone.web.user;
 
+import com.gokimpark.instaclone.domain.exception.AccountException;
 import com.gokimpark.instaclone.domain.user.UserService;
 import com.gokimpark.instaclone.domain.user.dto.UserDto;
 import com.gokimpark.instaclone.web.user.dto.JoinDto;
@@ -38,9 +39,14 @@ public class AccountViewController {
         if(bindingResult.hasErrors()) {
             return "account/create";
         }
-        UserDto user = userService.createAccount(joinDto);
-        HttpSession session = httpServletRequest.getSession();
-        session.setAttribute("username", user.getUsername());
+        try {
+            UserDto user = userService.createAccount(joinDto);
+            HttpSession session = httpServletRequest.getSession();
+            session.setAttribute("username", user.getUsername());
+        } catch (AccountException e) {
+            bindingResult.reject("duplicate.joinDto.username", e.getMessage());
+            return "account/create";
+        }
         return "redirect:/";
     }
 
@@ -56,9 +62,14 @@ public class AccountViewController {
         if(bindingResult.hasErrors()) {
             return "account/login";
         }
-        UserDto user = userService.login(loginDto.getLoginId(), loginDto.getPassword());
-        HttpSession session = httpServletRequest.getSession();
-        session.setAttribute("username", user.getUsername());
+        try {
+            UserDto user = userService.login(loginDto.getLoginId(), loginDto.getPassword());
+            HttpSession session = httpServletRequest.getSession();
+            session.setAttribute("username", user.getUsername());
+        } catch (AccountException e) {
+            bindingResult.reject("mismatch", e.getMessage());
+            return "account/login";
+        }
         return "redirect:/";
     }
 

--- a/src/main/java/com/gokimpark/instaclone/web/user/AccountViewController.java
+++ b/src/main/java/com/gokimpark/instaclone/web/user/AccountViewController.java
@@ -15,6 +15,9 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 @Slf4j
 @Controller
 @RequiredArgsConstructor
@@ -30,11 +33,14 @@ public class AccountViewController {
     }
 
     @PostMapping("/create")
-    public String createAccount(@Validated @ModelAttribute JoinDto joinDto, BindingResult bindingResult) {
+    public String createAccount(@Validated @ModelAttribute JoinDto joinDto, BindingResult bindingResult,
+                                HttpServletRequest httpServletRequest) {
         if(bindingResult.hasErrors()) {
             return "account/create";
         }
         UserDto user = userService.createAccount(joinDto);
+        HttpSession session = httpServletRequest.getSession();
+        session.setAttribute("username", user.getUsername());
         return "redirect:/";
     }
 
@@ -45,11 +51,23 @@ public class AccountViewController {
     }
 
     @PostMapping("/login")
-    public String login(@Validated @ModelAttribute LoginDto loginDto, BindingResult bindingResult) {
+    public String login(@Validated @ModelAttribute LoginDto loginDto, BindingResult bindingResult,
+                        HttpServletRequest httpServletRequest) {
         if(bindingResult.hasErrors()) {
             return "account/login";
         }
         UserDto user = userService.login(loginDto.getLoginId(), loginDto.getPassword());
+        HttpSession session = httpServletRequest.getSession();
+        session.setAttribute("username", user.getUsername());
+        return "redirect:/";
+    }
+
+    @GetMapping("/logout")
+    public String logout(HttpServletRequest httpServletRequest) {
+        HttpSession session = httpServletRequest.getSession();
+        if(session != null) {
+            session.invalidate();
+        }
         return "redirect:/";
     }
 }

--- a/src/main/java/com/gokimpark/instaclone/web/user/HomeController.java
+++ b/src/main/java/com/gokimpark/instaclone/web/user/HomeController.java
@@ -1,17 +1,28 @@
 package com.gokimpark.instaclone.web.user;
 
+import com.gokimpark.instaclone.domain.user.UserService;
+import com.gokimpark.instaclone.domain.user.dto.UserDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.SessionAttribute;
 
 @Slf4j
 @Controller
 @RequiredArgsConstructor
 public class HomeController {
 
+    private final UserService userService;
+
     @GetMapping("/")
-    public String home() {
-        return "loginHome";
+    public String home(@SessionAttribute(required = false) String username, Model model) {
+        if(username == null) {
+            return "loginHome";
+        }
+        UserDto user = userService.findByUsername(username);
+        model.addAttribute("user", user);
+        return "userHome";
     }
 }

--- a/src/main/java/com/gokimpark/instaclone/web/user/dto/LoginDto.java
+++ b/src/main/java/com/gokimpark/instaclone/web/user/dto/LoginDto.java
@@ -1,9 +1,7 @@
 package com.gokimpark.instaclone.web.user.dto;
 
 import lombok.Data;
-
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
 
 @Data
 public class LoginDto {
@@ -12,6 +10,5 @@ public class LoginDto {
     private String loginId;
 
     @NotBlank
-    @Size(min = 6)
     private String password;
 }

--- a/src/main/resources/errors.properties
+++ b/src/main/resources/errors.properties
@@ -1,4 +1,2 @@
-#==Account Error==
-#Level1
-mismatch.loginid=입력한 사용자 이름을 사용하는 계정을 찾을 수 없습니다. 사용자 이름을 확인하고 다시 시도하세요.
-mismatch.password=잘못된 비밀번호입니다. 다시 확인하세요.
+duplicate.joinDto.username=이미 사용중인 이름입니다.
+duplicate=중복되는 데이터입니다.

--- a/src/main/resources/templates/account/create.html
+++ b/src/main/resources/templates/account/create.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:replace="fragments/header :: header">
     <meta charset="utf-8">
+    <link th:href="@{../static/css/bootstrap.min.css}" rel="stylesheet">
     <style>
         .container{
             max-width: 560px;
@@ -17,24 +18,28 @@
     <div th:replace="fragments/bodyHeader :: bodyHeader"></div>
     <form role="form" action="/account/create" th:object="${joinDto}" method="post">
 
+        <div th:if="${#fields.hasGlobalErrors()}">
+            <p class="field-error" th:each="err : ${#fields.globalErrors()}" th:text="${err}"></p>
+        </div>
+
         <div class="form-group">
-            <input type="text" th:field="*{email}"
-                           class="form-control" placeholder="휴대폰 번호 또는 이메일 주소">
+            <input type="text" th:field="*{email}" class="form-control" placeholder="이메일 주소">
         </div>
         <br>
         <div class="form-group">
-            <input type="text" th:field="*{name}"
-                               class="form-control" placeholder="성명">
+            <input type="text" th:field="*{name}" class="form-control" placeholder="성명">
         </div>
         <br>
         <div class="form-group">
             <input type="text" th:field="*{username}"
-                       class="form-control" placeholder="사용자 이름">
+                   th:errorclass="field-error" class="form-control" placeholder="사용자 이름">
+            <div class="field-error" th:errors="*{username}"></div>
         </div>
         <br>
         <div class="form-group">
             <input type="password" th:field="*{password}"
-                   class="form-control" placeholder="비밀번호">
+                   th:errorclass="field-error" class="form-control" placeholder="비밀번호">
+            <div class="field-error" th:errors="*{password}"></div>
         </div>
         <br>
         <button type="submit" class="btn btn-primary">가입</button>

--- a/src/main/resources/templates/account/login.html
+++ b/src/main/resources/templates/account/login.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:replace="fragments/header :: header">
     <meta charset="utf-8">
+    <link th:href="@{../static/css/bootstrap.min.css}" rel="stylesheet">
     <style>
         .container{
             max-width: 560px;
@@ -18,14 +19,20 @@
     <div th:replace="fragments/bodyHeader :: bodyHeader"></div>
     <form role="form" action="/account/login" th:object="${loginDto}" method="post">
 
+        <div th:if="${#fields.hasGlobalErrors()}">
+            <p class="field-error" th:each="err : ${#fields.globalErrors()}" th:text="${err}"></p>
+        </div>
+
         <div class="form-group">
             <input type="text" th:field="*{loginId}"
-                   class="form-control" placeholder="전화번호, 사용자 이름 또는 이메일">
+                   th:errorclass="field-error" class="form-control" placeholder="전화번호, 사용자 이름 또는 이메일">
+            <div class="field-error" th:errors="*{loginId}"></div>
         </div>
         <br>
         <div class="form-group">
             <input type="password" th:field="*{password}"
-                   class="form-control" placeholder="비밀번호">
+                   th:errorclass="field-error" class="form-control" placeholder="비밀번호">
+            <div class="field-error" th:errors="*{password}"></div>
         </div>
         <br>
         <button type="submit" class="btn btn-primary">로그인</button>

--- a/src/main/resources/templates/account/profile.html
+++ b/src/main/resources/templates/account/profile.html
@@ -6,12 +6,34 @@
 <div th:class="container">
     <div th:replace="fragments/bodyHeader :: bodyHeader"></div>
     <h2 th:text="${profileDto.userInfo.username}"></h2>
-    <ul>
-        <li><span th:text="${profileDto.userInfo.name}"></span></li>
-        <li>Posts <span th:text="${profileDto.userInfo.getPostCount()}"></span></li>
-        <li>Followers <span th:text="${profileDto.userInfo.getFollowerCount()}"></span></li>
-        <li>Following <span th:text="${profileDto.userInfo.getFollowingCount()}"></span></li>
-    </ul>
+    <br>
+
+    <div class="row justify-content-center">
+        <div class="col">
+          <h4 th:text="${profileDto.userInfo.name}"></h4>
+        </div>
+        <div class="col">
+            <button class="btn btn-light btn-sm">Posts <span th:text="${profileDto.userInfo.getPostCount()}"></span></button>
+        </div>
+        <div class="col">
+            <a th:href="@{/follower/{profileUsername}/{requestedUsername}
+                         (profileUsername=${profileDto.userInfo.username}, requestedUsername=${profileDto.userInfo.requestedUsername})}">
+                <button type="submit" class="btn btn-light btn-sm">
+                Followers <span th:text="${profileDto.userInfo.getFollowerCount()}"></span>
+                </button>
+            </a>
+        </div>
+        <div class="col">
+            <a th:href="@{/following/{profileUsername}/{requestedUsername}
+                         (profileUsername=${profileDto.userInfo.username}, requestedUsername=${profileDto.userInfo.requestedUsername})}">
+                <button type="submit" class="btn btn-light btn-sm">
+                    Following <span th:text="${profileDto.userInfo.getFollowingCount()}"></span>
+                </button>
+            </a>
+        </div>
+    </div>
+    <br>
+
     <button class="btn btn-primary" th:if="${profileDto.isOneself}">Edit profile</button>
     <div th:unless="${profileDto.isOneself}">
         <button class="btn btn-primary">Follow</button>

--- a/src/main/resources/templates/account/profile.html
+++ b/src/main/resources/templates/account/profile.html
@@ -34,10 +34,24 @@
     </div>
     <br>
 
-    <button class="btn btn-primary" th:if="${profileDto.isOneself}">Edit profile</button>
+    <button th:if="${profileDto.isOneself}" type="button" class="btn btn-outline-secondary btn-sm">Edit profile</button>
     <div th:unless="${profileDto.isOneself}">
-        <button class="btn btn-primary">Follow</button>
-        <button class="btn btn-primary">Message</button>
+        <div class="row">
+            <div class="col">
+                <form th:if="${profileDto.userInfo.isFollowing}" method="post"
+                      th:action="@{/unfollow/{toUsername}/{fromUsername} (toUsername=${profileDto.userInfo.username}, fromUsername=${profileDto.userInfo.requestedUsername})}">
+                    <button type="submit" class="btn btn-secondary">Following</button>
+                </form>
+                <form th:unless="${profileDto.userInfo.isFollowing}" method="post"
+                      th:action="@{/follow/{toUsername}/{fromUsername} (toUsername=${profileDto.userInfo.username}, fromUsername=${profileDto.userInfo.requestedUsername})}">
+                    <button type="submit" class="btn btn-primary">Follow</button>
+                </form>
+            </div>
+            <div class="col">
+                <button type="button" class="btn btn-outline-secondary">Message</button>
+            </div>
+        </div>
+
     </div>
     <div th:replace="fragments/footer:: footer"></div>
 </div>

--- a/src/main/resources/templates/account/userList.html
+++ b/src/main/resources/templates/account/userList.html
@@ -14,8 +14,22 @@
             </thead>
             <tbody>
             <tr th:each="user : ${users}">
-                <td th:text="${user.username}"></td>
+                <td>
+                    <button class="btn btn-outline-secondary" th:text="${user.username}"
+                            th:onclick="|location.href='@{/profile/{toUsername}/{fromUsername} (toUsername=${user.username}, fromUsername=${user.requestedUsername})}'|">
+                    </button>
+                </td>
                 <td th:text="${user.name}"></td>
+                <td>
+                    <form th:if="${user.isFollowing}" method="post"
+                          th:action="@{/unfollow/{toUsername}/{fromUsername} (toUsername=${user.username}, fromUsername=${user.requestedUsername})}">
+                        <button type="submit" class="btn btn-secondary">Following</button>
+                    </form>
+                    <form th:unless="${user.isFollowing}" method="post"
+                       th:action="@{/follow/{toUsername}/{fromUsername} (toUsername=${user.username}, fromUsername=${user.requestedUsername})}">
+                        <button type="submit" class="btn btn-primary">Follow</button>
+                    </form>
+                </td>
             </tr>
             </tbody>
         </table>


### PR DESCRIPTION
## 팔로우, 팔로잉 목록을 보는 기준을 변경

- 사용자A 자신의 팔로잉 목록을 본다면 해당되는 모든 사용자에 대해 **현재 팔로우하는 관계** 라는 상태를 보여아함
- 사용자A 가 사용자 B의 팔로잉 목록을 본다면 사용자 B가 팔로우 중인 목록이 출력되지만 해당되는 모든 사용자에 대해 사용자A 와의 팔로우 상태를 보여야함
- 즉, 특정 사용자(from user)의 팔로잉, 팔로우를 보고싶어서 요청하는 사용자(requested user) 로 개념을 분리함

## 입력 폼에 대한 에러 추가

- 가입과 로그인 데이터 입력시 사용자가 잘못된 데이터 작성으로 발생하는 오류를 출력해줌으로써 사용자가 빠르게 문제점을 파악할 수 있는 서비스를 제공함