### PR TITLE
Follow status 설정시 발생하는 JPA N+1 query 문제 해결

### DIFF
--- a/src/main/java/com/gokimpark/instaclone/aspect/Pointcuts.java
+++ b/src/main/java/com/gokimpark/instaclone/aspect/Pointcuts.java
@@ -6,4 +6,10 @@ public class Pointcuts {
 
     @Pointcut("execution(* com.gokimpark.instaclone.domain..*(..))")
     public void serviceAndRepoLayer(){}
+
+    @Pointcut("within(com.gokimpark.instaclone.domain..*Service)")
+    public void allService(){}
+
+    @Pointcut("within(com.gokimpark.instaclone.web..*Controller)")
+    public void allController(){}
 }

--- a/src/main/java/com/gokimpark/instaclone/aspect/TraceAspect.java
+++ b/src/main/java/com/gokimpark/instaclone/aspect/TraceAspect.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class TraceAspect {
 
-    @Around("com.gokimpark.instaclone.aspect.Pointcuts.serviceAndRepoLayer() && @target(trace)")
-    public Object doTrace(ProceedingJoinPoint joinPoint, Trace trace) throws Throwable {
+    @Around("com.gokimpark.instaclone.aspect.Pointcuts.serviceAndRepoLayer()")
+    public Object doTrace(ProceedingJoinPoint joinPoint) throws Throwable {
         try {
             log.info("[Trace begin] {}", joinPoint.getSignature());
             Object result = joinPoint.proceed();

--- a/src/main/java/com/gokimpark/instaclone/domain/follow/FollowService.java
+++ b/src/main/java/com/gokimpark/instaclone/domain/follow/FollowService.java
@@ -55,29 +55,27 @@ public class FollowService {
         if(toUsername.equals(fromUsername)) throw new FollowException("follower 와 following 의 대상이 동일합니다.");
     }
 
-    public List<UserSimpleInfoDto> getFollowRelationList(String follow, String profileUsername, String requestedUsername){
-        User profileUser = userRepository.findByUsername(profileUsername).orElseThrow(UserException::new);
-        User requestedUser = userRepository.findByUsername(requestedUsername).orElseThrow(UserException::new);
+    public List<UserSimpleInfoDto> getFollowRelationList(String follow, String username, String requestingUsername){
+        User user = userRepository.findByUsername(username).orElseThrow(UserException::new);
+        User requestingUser = userRepository.findByUsername(requestingUsername).orElseThrow(UserException::new);
 
         List<UserSimpleInfoDto> followList = null;
         if(follow.equals("following")) {
-            followList = followRepository.findAllByFromUser(profileUser.getId());
+            followList = followRepository.findAllByFromUser(user.getId());
         }
         else if(follow.equals("follower")) {
-            followList = followRepository.findAllByToUser(profileUser.getId());
+            followList = followRepository.findAllByToUser(user.getId());
         }
         assert followList != null;
         for(UserSimpleInfoDto userSimpleInfoDto : followList) {
-            userSimpleInfoDto.setRequestedUsername(requestedUsername);
-            if(profileUsername.equals(requestedUsername)) {
+            userSimpleInfoDto.setRequestingUsername(requestingUsername);
+            if(userSimpleInfoDto.getUsername().equals(requestingUsername)) continue;
+            if(username.equals(requestingUsername)) {
                 userSimpleInfoDto.setFollowStatus(FollowStatus.FOLLOWING);
             }
-            else if(userSimpleInfoDto.getUsername().equals(requestedUsername)) {
-                userSimpleInfoDto.setFollowStatus(FollowStatus.ONESELF);
-            }
             else {
-                User toUser = userRepository.findByUsername(userSimpleInfoDto.getUsername()).orElseThrow(UserException::new);
-                if(isFollowingById(toUser.getId(), requestedUser.getId()))
+                User userFollowByToUser = userRepository.findByUsername(userSimpleInfoDto.getUsername()).orElseThrow(UserException::new);
+                if(isFollowingById(userFollowByToUser.getId(), requestingUser.getId()))
                     userSimpleInfoDto.setFollowStatus(FollowStatus.FOLLOWING);
                 else
                     userSimpleInfoDto.setFollowStatus(FollowStatus.UNFOLLOW);

--- a/src/main/java/com/gokimpark/instaclone/domain/user/ProfileService.java
+++ b/src/main/java/com/gokimpark/instaclone/domain/user/ProfileService.java
@@ -34,7 +34,7 @@ public class ProfileService {
 
         ProfileDto profileDto = new ProfileDto();
         ProfileUserInfoDto userInfoDto = mapper.map(toUser, ProfileUserInfoDto.class);
-        userInfoDto.setRequestedUsername(fromUsername);
+        userInfoDto.setRequestingUsername(fromUsername);
         if(fromUser.getId().equals(toUser.getId())) {
             profileDto.setIsOneself(true);
         }
@@ -59,7 +59,7 @@ public class ProfileService {
         for(UserDto user : users) {
             if(user.getUsername().equals(username)) continue;
             UserSimpleInfoDto userSimpleInfoDto = new UserSimpleInfoDto(user.getUsername(), user.getName());
-            userSimpleInfoDto.setRequestedUsername(username);
+            userSimpleInfoDto.setRequestingUsername(username);
 
             if(followService.isFollowingByUsername(user.getUsername(), username))
                 userSimpleInfoDto.setFollowStatus(FollowStatus.FOLLOWING);

--- a/src/main/java/com/gokimpark/instaclone/domain/user/dto/ProfileUserInfoDto.java
+++ b/src/main/java/com/gokimpark/instaclone/domain/user/dto/ProfileUserInfoDto.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.NotBlank;
 public class ProfileUserInfoDto {
 
     private boolean isFollowing;
-    private String requestedUsername;
+    private String requestingUsername;
     @NotBlank
     private String name;
     @NotBlank

--- a/src/main/java/com/gokimpark/instaclone/domain/user/dto/UserSimpleInfoDto.java
+++ b/src/main/java/com/gokimpark/instaclone/domain/user/dto/UserSimpleInfoDto.java
@@ -6,7 +6,7 @@ import lombok.Data;
 @Data
 public class UserSimpleInfoDto {
 
-    private String requestedUsername;
+    private String requestingUsername;
     private FollowStatus followStatus;
 
     private String username;

--- a/src/main/java/com/gokimpark/instaclone/web/follow/FollowApiController.java
+++ b/src/main/java/com/gokimpark/instaclone/web/follow/FollowApiController.java
@@ -41,13 +41,13 @@ public class FollowApiController {
 
     @GetMapping("/follower/{profileUsername}/{requestedUsername}")
     public ResponseEntity<?> getFollower(@PathVariable String profileUsername, @PathVariable String requestedUsername){
-        List<UserSimpleInfoDto> followerList = followService.getFollowRelationList("follower", profileUsername, requestedUsername);
+        List<UserSimpleInfoDto> followerList = followService.getFollowerList(profileUsername, requestedUsername);
         return new ResponseEntity<>(followerList, HttpStatus.OK);
     }
 
     @GetMapping("/following/{profileUsername}/{requestedUsername}")
     public ResponseEntity<?> getFollowing(@PathVariable String profileUsername, @PathVariable String requestedUsername){
-        List<UserSimpleInfoDto> followingList = followService.getFollowRelationList("following", profileUsername, requestedUsername);
+        List<UserSimpleInfoDto> followingList = followService.getFollowingList(profileUsername, requestedUsername);
         return new ResponseEntity<>(followingList, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/gokimpark/instaclone/web/follow/FollowController.java
+++ b/src/main/java/com/gokimpark/instaclone/web/follow/FollowController.java
@@ -33,14 +33,14 @@ public class FollowController {
 
     @GetMapping("/follower/{username}/{requestingUsername}")
     public String getFollower(@PathVariable String username, @PathVariable String requestingUsername, Model model){
-        List<UserSimpleInfoDto> followerList = followService.getFollowRelationList("follower", username, requestingUsername);
+        List<UserSimpleInfoDto> followerList = followService.getFollowerList(username, requestingUsername);
         model.addAttribute("users", followerList);
         return "/account/userList";
     }
 
     @GetMapping("/following/{username}/{requestingUsername}")
     public String getFollowing(@PathVariable String username, @PathVariable String requestingUsername, Model model){
-        List<UserSimpleInfoDto> followingList = followService.getFollowRelationList("following", username, requestingUsername);
+        List<UserSimpleInfoDto> followingList = followService.getFollowingList(username, requestingUsername);
         model.addAttribute("users", followingList);
         return "/account/userList";
     }

--- a/src/main/java/com/gokimpark/instaclone/web/follow/FollowController.java
+++ b/src/main/java/com/gokimpark/instaclone/web/follow/FollowController.java
@@ -2,7 +2,6 @@ package com.gokimpark.instaclone.web.follow;
 
 import com.gokimpark.instaclone.domain.follow.FollowService;
 import com.gokimpark.instaclone.domain.user.dto.UserSimpleInfoDto;
-import com.gokimpark.instaclone.domain.user.ProfileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -19,7 +18,6 @@ import java.util.List;
 public class FollowController {
 
     private final FollowService followService;
-    private final ProfileService profileService;
 
     @PostMapping("/follow/{toUsername}/{fromUsername}")
     public String addFollow(@PathVariable String toUsername, @PathVariable String fromUsername){
@@ -33,16 +31,16 @@ public class FollowController {
         return "redirect:/profile/{toUsername}/{fromUsername}";
     }
 
-    @GetMapping("/follower/{fromUsername}/{requestedUsername}")
-    public String getFollower(@PathVariable String fromUsername, @PathVariable String requestedUsername, Model model){
-        List<UserSimpleInfoDto> followerList = followService.getFollowRelationList("follower", fromUsername, requestedUsername);
+    @GetMapping("/follower/{username}/{requestingUsername}")
+    public String getFollower(@PathVariable String username, @PathVariable String requestingUsername, Model model){
+        List<UserSimpleInfoDto> followerList = followService.getFollowRelationList("follower", username, requestingUsername);
         model.addAttribute("users", followerList);
         return "/account/userList";
     }
 
-    @GetMapping("/following/{fromUsername}/{requestedUsername}")
-    public String getFollowing(@PathVariable String fromUsername, @PathVariable String requestedUsername, Model model){
-        List<UserSimpleInfoDto> followingList = followService.getFollowRelationList("following", fromUsername, requestedUsername);
+    @GetMapping("/following/{username}/{requestingUsername}")
+    public String getFollowing(@PathVariable String username, @PathVariable String requestingUsername, Model model){
+        List<UserSimpleInfoDto> followingList = followService.getFollowRelationList("following", username, requestingUsername);
         model.addAttribute("users", followingList);
         return "/account/userList";
     }

--- a/src/main/java/com/gokimpark/instaclone/web/user/ProfileApiController.java
+++ b/src/main/java/com/gokimpark/instaclone/web/user/ProfileApiController.java
@@ -30,7 +30,7 @@ public class ProfileApiController {
         if(bindingResult.hasErrors())
             return new ResponseEntity<>(profileRequestDto, HttpStatus.BAD_REQUEST);
 
-        ProfileDto profileDto = profileService.getProfile(profileRequestDto.getTargetUsername(), profileRequestDto.getRequestedUsername());
+        ProfileDto profileDto = profileService.getProfile(profileRequestDto.getToUsername(), profileRequestDto.getFromUsername());
         return new ResponseEntity<>(profileDto, HttpStatus.OK);
     }
 

--- a/src/main/java/com/gokimpark/instaclone/web/user/dto/ProfileRequestDto.java
+++ b/src/main/java/com/gokimpark/instaclone/web/user/dto/ProfileRequestDto.java
@@ -8,8 +8,8 @@ import javax.validation.constraints.NotBlank;
 public class ProfileRequestDto {
 
     @NotBlank
-    private String targetUsername;
+    private String toUsername;
 
     @NotBlank
-    private String requestedUsername;
+    private String fromUsername;
 }

--- a/src/main/resources/templates/account/profile.html
+++ b/src/main/resources/templates/account/profile.html
@@ -16,16 +16,16 @@
             <button class="btn btn-light" th:text="#{post} + ' ' + ${profileDto.userInfo.getPostCount()}">Posts</button>
         </div>
         <div class="col">
-            <a th:href="@{/follower/{profileUsername}/{requestedUsername}
-                         (profileUsername=${profileDto.userInfo.username}, requestedUsername=${profileDto.userInfo.requestedUsername})}">
+            <a th:href="@{/follower/{username}/{requestingUsername}
+                         (username=${profileDto.userInfo.username}, requestingUsername=${profileDto.userInfo.requestingUsername})}">
                 <button type="submit" class="btn btn-light"
                         th:text="#{follow.followers} + ' ' + ${profileDto.userInfo.getFollowerCount()}">
                 </button>
             </a>
         </div>
         <div class="col">
-            <a th:href="@{/following/{profileUsername}/{requestedUsername}
-                         (profileUsername=${profileDto.userInfo.username}, requestedUsername=${profileDto.userInfo.requestedUsername})}">
+            <a th:href="@{/following/{username}/{requestingUsername}
+                         (username=${profileDto.userInfo.username}, requestingUsername=${profileDto.userInfo.requestingUsername})}">
                 <button type="submit" class="btn btn-light"
                         th:text="#{follow.following} + ' ' + ${profileDto.userInfo.getFollowingCount()}">
                 </button>
@@ -39,11 +39,11 @@
         <div class="row">
             <div class="col">
                 <form th:if="${profileDto.userInfo.isFollowing}" method="post"
-                      th:action="@{/unfollow/{toUsername}/{fromUsername} (toUsername=${profileDto.userInfo.username}, fromUsername=${profileDto.userInfo.requestedUsername})}">
+                      th:action="@{/unfollow/{toUsername}/{fromUsername} (toUsername=${profileDto.userInfo.username}, fromUsername=${profileDto.userInfo.requestingUsername})}">
                     <button type="submit" class="btn btn-secondary col-md-5" th:text="#{follow.following}">Following</button>
                 </form>
                 <form th:unless="${profileDto.userInfo.isFollowing}" method="post"
-                      th:action="@{/follow/{toUsername}/{fromUsername} (toUsername=${profileDto.userInfo.username}, fromUsername=${profileDto.userInfo.requestedUsername})}">
+                      th:action="@{/follow/{toUsername}/{fromUsername} (toUsername=${profileDto.userInfo.username}, fromUsername=${profileDto.userInfo.requestingUsername})}">
                     <button type="submit" class="btn btn-primary col-md-5" th:text="#{follow.unfollow}">Follow</button>
                 </form>
             </div>

--- a/src/main/resources/templates/account/userList.html
+++ b/src/main/resources/templates/account/userList.html
@@ -17,17 +17,17 @@
             <tr th:each="user : ${users}">
                 <td>
                     <button class="btn btn-outline-secondary" th:text="${user.username}"
-                            th:onclick="|location.href='@{/profile/{toUsername}/{fromUsername} (toUsername=${user.username}, fromUsername=${user.requestedUsername})}'|">
+                            th:onclick="|location.href='@{/profile/{toUsername}/{fromUsername} (toUsername=${user.username}, fromUsername=${user.requestingUsername})}'|">
                     </button>
                 </td>
                 <td th:text="${user.name}"></td>
                 <td>
                     <form th:if="${T(com.gokimpark.instaclone.domain.follow.FollowStatus).FOLLOWING.equals(user.followStatus)}" method="post"
-                          th:action="@{/unfollow/{toUsername}/{fromUsername} (toUsername=${user.username}, fromUsername=${user.requestedUsername})}">
+                          th:action="@{/unfollow/{toUsername}/{fromUsername} (toUsername=${user.username}, fromUsername=${user.requestingUsername})}">
                         <button type="submit" class="btn btn-secondary" th:text="#{follow.following}">Following</button>
                     </form>
                     <form th:if="${T(com.gokimpark.instaclone.domain.follow.FollowStatus).UNFOLLOW.equals(user.followStatus)}" method="post"
-                       th:action="@{/follow/{toUsername}/{fromUsername} (toUsername=${user.username}, fromUsername=${user.requestedUsername})}">
+                       th:action="@{/follow/{toUsername}/{fromUsername} (toUsername=${user.username}, fromUsername=${user.requestingUsername})}">
                         <button type="submit" class="btn btn-primary" th:text="#{follow.unfollow}">Follow</button>
                     </form>
                 </td>


### PR DESCRIPTION
## Follow status 설정시 발생하는 JPA N+1 query 문제 해결

- HashSet 에 찾고자하는 사용자가 있는지 확인하는 방식으로 변경

<br>

## TraceAspect 에서 @target 제거

- 모든 Service layer 에 TraceAspect 를 적용하기 위함